### PR TITLE
Fix for Issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
         cap_add:
             - NET_ADMIN                         # Needs to be here
         environment: 
-            - KILL_SWITCH=true                  # Turns off internet access if the VPN connection drops
+            - KILL_SWITCH=on                    # Turns off internet access if the VPN connection drops
             - FORWARDED_PORTS=5794              # NUMBER TO REMEMBER FROM BEFORE, READ STEP 7 under STEP 1 (THIS IS CONFUSING AS IM TYPING IT, BUT READ IT)
         devices:
             - /dev/net/tun                      

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@
         cap_add:
             - NET_ADMIN                         # Needs to be here
         environment: 
-            - KILL_SWITCH=on                    # Turns off internet access if the VPN connection drops
-            - FORWARDED_PORTS=5794              # NUMBER TO REMEMBER FROM BEFORE, READ STEP 7 under STEP 1 (THIS IS CONFUSING AS IM TYPING IT, BUT READ IT)
+            - KILL_SWITCH=on                         # Turns off internet access if the VPN connection drops
+            - FORWARDED_PORTS=5794                   # NUMBER TO REMEMBER FROM BEFORE, READ STEP 7 under STEP 1 (THIS IS CONFUSING AS IM TYPING IT, BUT READ IT)
+            - SUBNETS=192.168.0.0/24,192.168.1.0/24  # Allows for the service to be accessed through LAN
         devices:
             - /dev/net/tun                      
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
         cap_add:
             - NET_ADMIN                         # Needs to be here
         environment: 
-            - KILL_SWITCH=true                  # Turns off internet access if the VPN connection drops
+            - KILL_SWITCH=on                    # Turns off internet access if the VPN connection drops
             - FORWARDED_PORTS=5794              # NUMBER TO REMEMBER FROM BEFORE, READ STEP 7 under STEP 1 (THIS IS CONFUSING AS IM TYPING IT, BUT READ IT)
         devices:
             - /dev/net/tun                      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@
         environment: 
             - KILL_SWITCH=on                    # Turns off internet access if the VPN connection drops
             - FORWARDED_PORTS=5794              # NUMBER TO REMEMBER FROM BEFORE, READ STEP 7 under STEP 1 (THIS IS CONFUSING AS IM TYPING IT, BUT READ IT)
+            - SUBNETS=192.168.0.0/24,192.168.1.0/24 # Allows for traffic outside the VPN tunnel
         devices:
             - /dev/net/tun                      
         volumes:


### PR DESCRIPTION
Fixes #4 
This is the fix for the issue that incorrectly enables the `KILL_SWITCH=` section of the Docker compose file.
Fixed it to achieve the expected outcome per the [documentation](https://hub.docker.com/r/yacht7/openvpn-client) of the Docker repo.