### PR TITLE
Fixes #2: Inability to access services behind VPN on LAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
         cap_add:
             - NET_ADMIN                         # Needs to be here
         environment: 
-            - KILL_SWITCH=true                  # Turns off internet access if the VPN connection drops
+            - KILL_SWITCH=on                    # Turns off internet access if the VPN connection drops
             - FORWARDED_PORTS=5794              # NUMBER TO REMEMBER FROM BEFORE, READ STEP 7 under STEP 1 (THIS IS CONFUSING AS IM TYPING IT, BUT READ IT)
         devices:
             - /dev/net/tun                      

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@
         cap_add:
             - NET_ADMIN                         # Needs to be here
         environment: 
-            - KILL_SWITCH=on                    # Turns off internet access if the VPN connection drops
-            - FORWARDED_PORTS=5794              # NUMBER TO REMEMBER FROM BEFORE, READ STEP 7 under STEP 1 (THIS IS CONFUSING AS IM TYPING IT, BUT READ IT)
+            - KILL_SWITCH=on                         # Turns off internet access if the VPN connection drops
+            - FORWARDED_PORTS=5794                   # NUMBER TO REMEMBER FROM BEFORE, READ STEP 7 under STEP 1 (THIS IS CONFUSING AS IM TYPING IT, BUT READ IT)
+            - SUBNETS=192.168.0.0/24,192.168.1.0/24  # Allows for the service to be accessed through LAN
         devices:
             - /dev/net/tun                      
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
         cap_add:
             - NET_ADMIN                         # Needs to be here
         environment: 
-            - KILL_SWITCH=true                  # Turns off internet access if the VPN connection drops
+            - KILL_SWITCH=on                    # Turns off internet access if the VPN connection drops
             - FORWARDED_PORTS=5794              # NUMBER TO REMEMBER FROM BEFORE, READ STEP 7 under STEP 1 (THIS IS CONFUSING AS IM TYPING IT, BUT READ IT)
         devices:
             - /dev/net/tun                      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@
         environment: 
             - KILL_SWITCH=on                    # Turns off internet access if the VPN connection drops
             - FORWARDED_PORTS=5794              # NUMBER TO REMEMBER FROM BEFORE, READ STEP 7 under STEP 1 (THIS IS CONFUSING AS IM TYPING IT, BUT READ IT)
+            - SUBNETS=192.168.0.0/24,192.168.1.0/24 # Allows for traffic outside the VPN tunnel
         devices:
             - /dev/net/tun                      
         volumes:


### PR DESCRIPTION
Fixes #2 
According to the [documentation](https://github.com/wfg/docker-openvpn-client#subnets) of the repo this is based on, the `SUBNETS=` environment variable fixes this issue.
As suggested by the documentation, I used `SUBNETS=192.168.0.0/24,192.168.1.0/24` and it allowed me to access my services from the LAN.